### PR TITLE
Fix eme controller configuration error

### DIFF
--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -307,8 +307,9 @@ class EMEController extends EventHandler {
           this.initDataType = event.initDataType;
 
           this.initData = event.initData;
-
-          this._configureEME();
+          if (this.manifestData) {
+            this._configureEME();
+          }
         }
         
       });


### PR DESCRIPTION
### This PR will...
Fix eme controller configuration error. I tried to do this properly with adding/removing listeners on media detaching and attaching events but our custom player doesn't properly detach old media. I tried to add support for detaching media and this error went away but then we had another null exception pop up in subtitle controller so I think there may be some issues with how hls.js handles attaching/detaching media but fixing this would be out of scope of this ticket.

The underlying issue is that hls remove reference to the old media element when a new one is attached but this is one of the few listeners that is attached to the old media element and not removed and it will still fire but there will be no data to configure with because all of that is attached to the new instance of the eme controller. My opinion is there isn't much reason to spend time fixing these nuances in the attaching/detaching media events because 1.0 will be out soon and its a rather small issue
### Why is this Pull Request needed?

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
